### PR TITLE
Refactor NuGet symbol package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ artifacts/
 
 # NuGet Packages
 *.nupkg
+*.snupkg
 **/packages/*
 
 # ReSharper

--- a/MvvmDialogs.Contrib.nuspec
+++ b/MvvmDialogs.Contrib.nuspec
@@ -21,5 +21,6 @@
   <files>
     <file src="src\net\bin\Release\MvvmDialogs.Contrib.dll" target="lib\net45\MvvmDialogs.Contrib.dll" />
     <file src="src\net\bin\Release\MvvmDialogs.Contrib.xml" target="lib\net45\MvvmDialogs.Contrib.xml" />
+    <file src="src\net\bin\Release\MvvmDialogs.Contrib.pdb" target="lib\net45\MvvmDialogs.Contrib.pdb" />
   </files>
 </package>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,25 +28,29 @@ test:
 #             artifacts           #
 #---------------------------------#
 artifacts:
-  - path: '*.nupkg'
+  - path: '*.*nupkg'
     name: NuGet
-
-
-#---------------------------------#
-#            on finish            #
-#---------------------------------#
-on_finish:
-  - ps: Get-ChildItem -Path Failed_*.png -Recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+    type: NuGetPackage
 
 
 #---------------------------------#
 #              deploy             #
 #---------------------------------#
 deploy:
-  provider: NuGet
-  api_key:
-    secure: iw4U6OpEAxeZY5bNxWxK4RC+S2Jj6pvtLLyJ0b+YxpaZPoQbCAFZOXv9rfkzG109
-  skip_symbols: false
-  artifact: /.*\.nupkg/
-  on:
-    appveyor_repo_tag: true
+  - provider: GitHub
+    tag: ${APPVEYOR_REPO_TAG_NAME}
+    release: Release ${APPVEYOR_REPO_TAG_NAME}
+    description: TODO
+    auth_token:
+      secure: de2wnJZf6k7NY0XriDpf9BkrQ4MR5ZfDDWMM+H/K4OK3w0GpuJAMRj5PrO6tKu0K
+    artifact: NuGet
+    draft: true
+    on:
+      APPVEYOR_REPO_TAG: true
+  - provider: NuGet
+    api_key:
+      secure: iw4U6OpEAxeZY5bNxWxK4RC+S2Jj6pvtLLyJ0b+YxpaZPoQbCAFZOXv9rfkzG109
+    symbol_server: https://www.nuget.org
+    skip_symbols: false
+    on:
+      APPVEYOR_REPO_TAG: true

--- a/build.cake
+++ b/build.cake
@@ -5,7 +5,6 @@
 //////////////////////////////////////////////////////////////////////
 
 var target = Argument("target", "Default");
-var configuration = Argument("configuration", "Release");
 
 //////////////////////////////////////////////////////////////////////
 // VARIABLES
@@ -39,9 +38,13 @@ Task("Build")
     .IsDependentOn("Restore")
     .Does(() =>
     {
-        MSBuild(solution, settings => settings
-            .SetConfiguration(configuration)
-            .SetMaxCpuCount(0));    // Enable parallel build
+        MSBuild(
+            solution,
+            new MSBuildSettings
+            {
+                Configuration = "Release",
+                MaxCpuCount = 0,            // Enable parallel build
+            });
     });
 
 Task("Pack")
@@ -64,7 +67,8 @@ Task("Pack")
             new NuGetPackSettings
             {
                 Version = version,
-                Symbols = true
+                Symbols = true,
+                ArgumentCustomization = args => args.Append("-SymbolPackageFormat snupkg")
             });
     });
 


### PR DESCRIPTION
Update the build script to create a NuGet symbol package with the new `snupkg` format described in [Creating symbol packages (.snupkg)](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg).

The symbols will from now on be pushed to NuGet instead of https://nuget.smbsrc.net, since we lately have had some problems with latter.